### PR TITLE
Improve device detection and human-readable visit logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 NODE_ENV=development
 LOG_TO_FILE=true
 LOG_DIR=./data/logs
-IP_HASH_SALT=replace-with-a-long-random-string
 CONSENT_REQUIRED=false
 PORT=10000

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 logs/
+data/logs/
 *.log
 .env

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A minimal Express application that captures basic visit metadata and client-prov
 
 - Logs hashed IP, selected headers, and parsed user-agent data for each page view.
 - Collects non-invasive client hints (screen size, timezone, language, platform, hardware concurrency, optional device memory).
-- Persists visit records as JSON lines per day on disk and streams structured lines to stdout.
+- Persists visit records as human-readable text per day on disk and streams formatted lines to stdout.
 - Protects endpoints with Helmet, rate limiting, strict JSON/body size limits, and schema validation via Zod.
 - Consent banner controlled via `CONSENT_REQUIRED` environment variable (default `false`).
 - Includes `/healthz` endpoint for platform checks and a simple landing page that auto-posts telemetry when allowed.
@@ -25,9 +25,8 @@ The app listens on port `10000` by default. Configure via environment variables 
 See [`.env.example`](./.env.example) for defaults:
 
 - `NODE_ENV` – Node environment (`development`, `production`, etc.).
-- `LOG_TO_FILE` – When `true`, append visit logs to disk under `LOG_DIR`.
-- `LOG_DIR` – Directory for JSONL visit logs (defaults to `./data/logs`). Ensure it exists or mount a persistent volume.
-- `IP_HASH_SALT` – Required secret salt for hashing IP addresses before storage.
+- `LOG_TO_FILE` – When not set to `false`, append visit logs to disk under `LOG_DIR`.
+- `LOG_DIR` – Directory for text visit logs (defaults to `./data/logs`). Ensure it exists or mount a persistent volume.
 - `CONSENT_REQUIRED` – When `true`, visitors must click consent before client telemetry is sent.
 - `PORT` – Port to bind the HTTP server (defaults to `10000`).
 
@@ -39,13 +38,12 @@ See [`.env.example`](./.env.example) for defaults:
 4. Configure environment variables:
    - `LOG_TO_FILE=true`
    - `LOG_DIR=/data/logs`
-   - `IP_HASH_SALT=<long-random-string>`
    - `CONSENT_REQUIRED=false` (set to `true` if you want a consent banner)
 5. Set the health check path to `/healthz`.
-6. Deploy. Visit logs will appear in Render logs and persist under `/data/logs/visits-YYYY-MM-DD.jsonl` on the attached disk.
+6. Deploy. Visit logs will appear in Render logs and persist under `/data/logs/visits-YYYY-MM-DD.txt` on the attached disk.
 
 ## Privacy Notes
 
-- All IP addresses are hashed with a secret salt before logging.
+- All IP addresses are hashed with SHA-256 before logging.
 - Only basic device information is collected; no invasive fingerprinting techniques are used.
 - Server-side request metadata is logged on every hit for standard operational monitoring.

--- a/logger.js
+++ b/logger.js
@@ -4,12 +4,10 @@ import crypto from "crypto";
 import dayjs from "dayjs";
 import { mkdirp } from "mkdirp";
 
-const LOG_TO_FILE = process.env.LOG_TO_FILE === "true";
+const LOG_TO_FILE = process.env.LOG_TO_FILE !== "false";
 const LOG_DIR = process.env.LOG_DIR || "./data/logs";
-const SALT = process.env.IP_HASH_SALT || "dev-salt-do-not-use";
-
 export function hashIP(ip) {
-  const h = crypto.createHmac("sha256", SALT).update(ip || "").digest("hex");
+  const h = crypto.createHash("sha256").update(ip || "").digest("hex");
   // shorten to 16 bytes hex for readability
   return h.slice(0, 32);
 }
@@ -20,16 +18,101 @@ function ensureDir(dir) {
 
 function currentLogPath() {
   const date = dayjs().format("YYYY-MM-DD");
-  return path.join(LOG_DIR, `visits-${date}.jsonl`);
+  return path.join(LOG_DIR, `visits-${date}.txt`);
+}
+
+function formatRecord(record) {
+  const lines = [];
+  const headerParts = [
+    `[${record.ts}]`,
+    record.kind ? record.kind.toUpperCase() : "EVENT"
+  ];
+  if (record.path) {
+    headerParts.push(`path=${record.path}`);
+  }
+  if (record.method) {
+    headerParts.push(`method=${record.method}`);
+  }
+  if (record.ipHash) {
+    headerParts.push(`ipHash=${record.ipHash}`);
+  }
+  lines.push(headerParts.join(" | "));
+
+  if (record.device?.summary) {
+    lines.push(`  Device: ${record.device.summary}`);
+  } else if (record.device) {
+    const parts = [];
+    if (record.device.vendor || record.device.model) {
+      parts.push(
+        [record.device.vendor, record.device.model].filter(Boolean).join(" ")
+      );
+    }
+    if (record.device.type) {
+      parts.push(`type: ${record.device.type}`);
+    }
+    const osSummary = [
+      record.device.os?.name,
+      record.device.os?.version
+    ]
+      .filter(Boolean)
+      .join(" ");
+    if (osSummary) {
+      parts.push(`OS: ${osSummary}`);
+    }
+    const browserSummary = [
+      record.device.browser?.name,
+      record.device.browser?.version
+    ]
+      .filter(Boolean)
+      .join(" ");
+    if (browserSummary) {
+      parts.push(`Browser: ${browserSummary}`);
+    }
+    if (parts.length) {
+      lines.push(`  Device: ${parts.join(" | ")}`);
+    }
+  }
+
+  if (record.userAgent) {
+    lines.push(`  User-Agent: ${record.userAgent}`);
+  }
+
+  if (record.headers) {
+    const headerLines = Object.entries(record.headers)
+      .filter(([, value]) => Boolean(value))
+      .map(([key, value]) => `    ${key}: ${value}`);
+    if (headerLines.length) {
+      lines.push("  Headers:");
+      lines.push(...headerLines);
+    }
+  }
+
+  if (record.client) {
+    const clientEntries = Object.entries(record.client);
+    if (clientEntries.length) {
+      lines.push("  Client payload:");
+      clientEntries.forEach(([key, value]) => {
+        const serialised =
+          typeof value === "object" && value !== null
+            ? JSON.stringify(value)
+            : value;
+        lines.push(`    ${key}: ${serialised}`);
+      });
+    }
+  }
+
+  lines.push("---");
+
+  return `${lines.join("\n")}\n`;
 }
 
 export function writeVisit(record) {
-  const line = JSON.stringify(record) + "\n";
+  const formatted = formatRecord(record);
   // always emit to stdout for platform logs
-  process.stdout.write(line);
+  process.stdout.write(formatted);
 
   if (!LOG_TO_FILE) return;
 
   ensureDir(LOG_DIR);
-  fs.appendFileSync(currentLogPath(), line, { encoding: "utf8" });
+  fs.appendFileSync(currentLogPath(), formatted, { encoding: "utf8" });
 }

--- a/render.yaml
+++ b/render.yaml
@@ -13,8 +13,6 @@ services:
         value: "true"
       - key: LOG_DIR
         value: "/data/logs"
-      - key: IP_HASH_SALT
-        generateValue: true
       - key: CONSENT_REQUIRED
         value: "false"
     disk:

--- a/server.js
+++ b/server.js
@@ -13,6 +13,53 @@ const CONSENT_REQUIRED = process.env.CONSENT_REQUIRED === "true";
 
 app.disable("x-powered-by");
 
+function extractDeviceDetails(userAgent) {
+  const parser = new UAParser(userAgent || "");
+  const ua = parser.getResult();
+  const deviceDetails = {
+    type: ua.device?.type || null,
+    vendor: ua.device?.vendor || null,
+    model: ua.device?.model || null,
+    os: {
+      name: ua.os?.name || null,
+      version: ua.os?.version || null
+    },
+    browser: {
+      name: ua.browser?.name || null,
+      version: ua.browser?.version || null
+    }
+  };
+  const summaryParts = [];
+  if (deviceDetails.vendor || deviceDetails.model) {
+    summaryParts.push(
+      [deviceDetails.vendor, deviceDetails.model].filter(Boolean).join(" ")
+    );
+  }
+  if (deviceDetails.type) {
+    summaryParts.push(`type: ${deviceDetails.type}`);
+  }
+  const osSummary = [deviceDetails.os.name, deviceDetails.os.version]
+    .filter(Boolean)
+    .join(" ");
+  if (osSummary) {
+    summaryParts.push(`OS: ${osSummary}`);
+  }
+  const browserSummary = [
+    deviceDetails.browser.name,
+    deviceDetails.browser.version
+  ]
+    .filter(Boolean)
+    .join(" ");
+  if (browserSummary) {
+    summaryParts.push(`Browser: ${browserSummary}`);
+  }
+
+  return {
+    details: deviceDetails,
+    summary: summaryParts.join(" | ") || null
+  };
+}
+
 // security + parsing
 app.use(helmet());
 app.use(express.json({ limit: "32kb" }));
@@ -41,8 +88,10 @@ app.get("/healthz", (req, res) => res.status(200).send("ok"));
 // server-side visit log on every page request (minimal)
 app.use((req, _res, next) => {
   if (req.method === "GET" && req.accepts(["html", "json"]) === "html") {
-    const parser = new UAParser(req.headers["user-agent"]);
-    const ua = parser.getResult();
+    const userAgent = req.headers["user-agent"] || "";
+    const { details: deviceDetails, summary: deviceSummary } =
+      extractDeviceDetails(userAgent);
+
     const rawIP =
       req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
       req.socket.remoteAddress ||
@@ -55,6 +104,11 @@ app.use((req, _res, next) => {
       path: req.path,
       method: req.method,
       ipHash,
+      userAgent: userAgent || null,
+      device: {
+        ...deviceDetails,
+        summary: deviceSummary
+      },
       headers: {
         host: req.headers["host"],
         "accept-language": req.headers["accept-language"],
@@ -63,12 +117,6 @@ app.use((req, _res, next) => {
         "sec-ch-ua-mobile": req.headers["sec-ch-ua-mobile"],
         referer: req.headers["referer"],
         origin: req.headers["origin"]
-      },
-      uaParsed: {
-        browser: ua.browser,
-        os: ua.os,
-        device: ua.device,
-        engine: ua.engine
       }
     });
   }
@@ -83,6 +131,10 @@ app.post("/collect", (req, res) => {
   }
 
   const data = parse.data;
+  const userAgent = req.headers["user-agent"] || "";
+  const { details: deviceDetails, summary: deviceSummary } =
+    extractDeviceDetails(userAgent);
+
   const rawIP =
     req.headers["x-forwarded-for"]?.split(",")[0]?.trim() ||
     req.socket.remoteAddress ||
@@ -94,7 +146,12 @@ app.post("/collect", (req, res) => {
     kind: "client",
     ipHash,
     path: req.headers["referer"] || req.body?.ref || null,
-    client: data
+    client: data,
+    userAgent: userAgent || null,
+    device: {
+      ...deviceDetails,
+      summary: deviceSummary
+    }
   });
 
   res.json({ ok: true });


### PR DESCRIPTION
## Summary
- capture detailed device information from request user agents and include a friendly summary in visit records
- format visit logging output for readability and persist daily `.txt` files by default while still hashing IPs
- document the new log format, defaults, and ignore generated log directories in version control
- simplify IP hashing by removing the secret salt requirement and updating configuration guidance

## Testing
- node -e "import('./logger.js').then(m => {m.writeVisit({ts:new Date().toISOString(),kind:'pageview',path:'/',method:'GET',ipHash:m.hashIP('127.0.0.1'),userAgent:'TestAgent',device:{summary:'Sample Device Summary',browser:{},os:{}},headers:{host:'example.com',referer:null},client:{foo:'bar'}});}).catch(err=>{console.error(err);process.exit(1);});"

------
https://chatgpt.com/codex/tasks/task_e_68d6ffca9398832d84629d66866feb1f